### PR TITLE
Define cucumber as a peer dependency, upgrade to 0.10.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ npm install wdio-cucumber-framework --save-dev
 
 Instructions on how to install `WebdriverIO` can be found [here.](http://webdriver.io/guide/getstarted/install.html)
 
+### Install Cucumber
+
+Note that `cucumber` is defined as a peer dependency so make sure it is installed in your project as well.
+
+```json
+{
+  "devDependencies": {
+    "cucumber": "~0.10"
+  }
+}
+```
+
+You can simply do it by:
+
+```bash
+npm install cucumber --save-dev
+```
+
 ## Configuration
 
 Following code shows the default wdio test runner configuration...

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "homepage": "https://github.com/webdriverio/wdio-cucumber-framework#readme",
   "dependencies": {
-    "cucumber": "0.9.4",
     "wdio-sync": "0.4.8",
     "babel-runtime": "^5.8.25"
   },
@@ -57,6 +56,9 @@
     "q": "^1.4.1",
     "should": "^7.1.0",
     "sinon": "^1.17.1"
+  },
+  "peerDependencies": {
+    "cucumber": "^0.10.2"
   },
   "babel": {
     "env": {


### PR DESCRIPTION
This is to fix #7 
I noticed that Travis runs node 0.11 so it installs peer dependencies automatically.

Should the Travis build ever be configured to run on a node version which ships with npm >= 3.0.0 it will need the following in `.travis.yml`
```yml
before_script:
  - npm install cucumber
```