### PR TITLE
Fix cucumber peer dependency version pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Note that `cucumber` is defined as a peer dependency so make sure it is installe
 ```json
 {
   "devDependencies": {
-    "cucumber": "~0.10"
+    "cucumber": "^1.0.0"
   }
 }
 ```

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "sinon": "^1.17.1"
   },
   "peerDependencies": {
-    "cucumber": "^0.10.2"
+    "cucumber": ">=0.10.2"
   },
   "babel": {
     "env": {


### PR DESCRIPTION
Not a long time since https://github.com/webdriverio/wdio-cucumber-framework/pull/12 but the cucumber project released a new major version and this breaks the current peer dependency version pattern.

Pattern is now using a "greater than or equal" operator to ensure compatibility with new major versions.