### PR TITLE
compatibility with cucumber.js 1.2.0

### DIFF
--- a/lib/hookRunner.js
+++ b/lib/hookRunner.js
@@ -26,38 +26,110 @@ class HookRunner {
         return this.listener
     }
 
-    handleBeforeFeatureEvent (e, done) {
-        return executeHooksWithArgs(this.beforeFeature, [e.getPayloadItem('feature')]).then(done, (e) => {
+    handleBeforeFeatureEvent (event) {
+        const feature = event.getUri ? event : event.getPayloadItem('feature')
+        const exec = executeHooksWithArgs(this.beforeFeature, [feature])
+        const done = arguments[1]
+        if (done.length === 0) {
+            exec.then((res) => {
+                if (typeof done === 'function') {
+                    done(res)
+                }
+                return res
+            })
+        }
+
+        return exec.catch((e) => {
             console.error(`beforeFeature has thrown an error: ${e}`)
         })
     }
 
-    handleBeforeScenarioEvent (e, done) {
-        return executeHooksWithArgs(this.beforeScenario, [e.getPayloadItem('scenario')]).then(done, (e) => {
+    handleBeforeScenarioEvent (event) {
+        const scenario = event.getUri ? event : event.getPayloadItem('scenario')
+        const done = arguments[1]
+        const exec = executeHooksWithArgs(this.beforeScenario, [scenario])
+        if (done.length === 0) {
+            exec.then((res) => {
+                if (typeof done === 'function') {
+                    done(res)
+                }
+                return res
+            })
+        }
+
+        return exec.catch((e) => {
             console.error(`beforeScenario has thrown an error: ${e}`)
         })
     }
 
-    handleBeforeStepEvent (e, done) {
-        return executeHooksWithArgs(this.beforeStep, [e.getPayloadItem('step')]).then(done, (e) => {
+    handleBeforeStepEvent (event) {
+        const step = event.getUri ? event : event.getPayloadItem('step')
+        const done = arguments[1]
+        const exec = executeHooksWithArgs(this.beforeStep, [step])
+        if (done.length === 0) {
+            exec.then((res) => {
+                if (typeof done === 'function') {
+                    done(res)
+                }
+                return res
+            })
+        }
+
+        return exec.catch((e) => {
             console.error(`beforeStep has thrown an error: ${e}`)
         })
     }
 
-    handleStepResultEvent (e, done) {
-        return executeHooksWithArgs(this.afterStep, [e.getPayloadItem('stepResult')]).then(done, (e) => {
+    handleStepResultEvent (event) {
+        const stepResult = event.getStep ? event : event.getPayloadItem('stepResult')
+        const done = arguments[1]
+        const exec = executeHooksWithArgs(this.afterStep, [stepResult])
+        if (done.length === 0) {
+            exec.then((res) => {
+                if (typeof done === 'function') {
+                    done(res)
+                }
+                return res
+            })
+        }
+
+        return exec.catch((e) => {
             console.error(`afterStep has thrown an error: ${e}`)
         })
     }
 
-    handleAfterScenarioEvent (e, done) {
-        return executeHooksWithArgs(this.afterScenario, [e.getPayloadItem('scenario')]).then(done, (e) => {
+    handleAfterScenarioEvent (event) {
+        const scenario = event.getUri ? event : event.getPayloadItem('scenario')
+        const done = arguments[1]
+        const exec = executeHooksWithArgs(this.afterScenario, [scenario])
+        if (done.length === 0) {
+            exec.then((res) => {
+                if (typeof done === 'function') {
+                    done(res)
+                }
+                return res
+            })
+        }
+
+        return exec.catch((e) => {
             console.error(`afterScenario has thrown an error: ${e}`)
         })
     }
 
-    handleAfterFeatureEvent (e, done) {
-        return executeHooksWithArgs(this.afterFeature, [e.getPayloadItem('feature')]).then(done, (e) => {
+    handleAfterFeatureEvent (event) {
+        const feature = event.getUri ? event : event.getPayloadItem('feature')
+        const done = arguments[1]
+        const exec = executeHooksWithArgs(this.afterFeature, [feature])
+        if (done.length === 0) {
+            exec.then((res) => {
+                if (typeof done === 'function') {
+                    done(res)
+                }
+                return res
+            })
+        }
+
+        return exec.catch((e) => {
             console.error(`afterFeature has thrown an error: ${e}`)
         })
     }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -24,7 +24,7 @@ class CucumberReporter {
     }
 
     handleBeforeFeatureEvent (event, callback) {
-        let feature = event.getPayloadItem('feature')
+        const feature = event.getUri ? event : event.getPayloadItem('feature')
         this.featureStart = new Date()
         this.runningFeature = feature
 
@@ -38,7 +38,7 @@ class CucumberReporter {
     }
 
     handleBeforeScenarioEvent (event, callback) {
-        let scenario = event.getPayloadItem('scenario')
+        const scenario = event.getUri ? event : event.getPayloadItem('scenario')
         this.runningScenario = scenario
         this.scenarioStart = new Date()
         this.testStart = new Date()
@@ -54,7 +54,7 @@ class CucumberReporter {
     }
 
     handleBeforeStepEvent (event, callback) {
-        let step = event.getPayloadItem('step')
+        const step = event.getUri ? event : event.getPayloadItem('step')
         this.testStart = new Date()
 
         this.emit('test:start', {
@@ -69,7 +69,7 @@ class CucumberReporter {
     }
 
     handleStepResultEvent (event, callback) {
-        let stepResult = event.getPayloadItem('stepResult')
+        const stepResult = event.getStep ? event : event.getPayloadItem('stepResult')
         let step = stepResult.getStep()
         let e = 'undefined'
 
@@ -141,8 +141,7 @@ class CucumberReporter {
     }
 
     handleAfterScenarioEvent (event, callback) {
-        let scenario = event.getPayloadItem('scenario')
-
+        const scenario = event.getUri ? event : event.getPayloadItem('scenario')
         this.emit('suite:end', {
             title: scenario.getName(),
             parent: this.runningFeature.getName(),
@@ -155,8 +154,7 @@ class CucumberReporter {
     }
 
     handleAfterFeatureEvent (event, callback) {
-        let feature = event.getPayloadItem('feature')
-
+        const feature = event.getUri ? event : event.getPayloadItem('feature')
         this.emit('suite:end', {
             title: feature.getName(),
             type: 'suite',


### PR DESCRIPTION
This change allows the use of cucumber 1.0.0 or 1.2.0.

I'm not too happy with it but API changes in cucumber js mean  1.2.0 is not completely backwards compatible with 1.0.0.

A lot of the changes could be removed if we change the peer dep to to be 1.2.0 instead, if you'd rather do that I'll happily change it

