### PR TITLE
fix: use cucumber library class to set default timeout

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -42,7 +42,7 @@ class CucumberAdapter {
         this.cucumberOpts = Object.assign(DEFAULT_OPTS, config.cucumberOpts)
 
         this.origStepDefinition = Cucumber.SupportCode.StepDefinition
-        this.origAstTreeWalker = Cucumber.Runtime.AstTreeWalker
+        this.origLibrary = Cucumber.SupportCode.Library
     }
 
     async run () {
@@ -57,7 +57,7 @@ class CucumberAdapter {
         let runtime = Cucumber.Runtime(cucumberConf)
 
         Cucumber.SupportCode.StepDefinition = this.getStepDefinition()
-        Cucumber.Runtime.AstTreeWalker = this.getAstTreeWalker()
+        Cucumber.SupportCode.Library = this.getLibrary()
 
         let reporter = new CucumberReporter(Cucumber.Listener(), reporterOptions, this.cid, this.specs)
         runtime.attachListener(reporter.getListener())
@@ -70,7 +70,7 @@ class CucumberAdapter {
             runtime.start(() => {
                 resolve(reporter.failedCount)
                 Cucumber.SupportCode.StepDefinition = this.origStepDefinition
-                Cucumber.Runtime.AstTreeWalker = this.origAstTreeWalker
+                Cucumber.SupportCode.Library = this.origLibrary
             })
         })
         await executeHooksWithArgs(this.config.after, [result, this.capabilities, this.specs])
@@ -96,13 +96,14 @@ class CucumberAdapter {
     }
 
     /**
-     * overwrites Cucumbers AstTreeWalker class to set default timeout for cucumber steps
+     * overwrites Cucumbers Library class to set default timeout for cucumber steps and hooks
      */
-    getAstTreeWalker () {
-        let { origAstTreeWalker } = this
-        return (features, supportCodeLibrary, listeners, options) => {
-            supportCodeLibrary.setDefaultTimeout(this.cucumberOpts.timeout)
-            return origAstTreeWalker(features, supportCodeLibrary, listeners, options)
+    getLibrary () {
+        let { origLibrary } = this
+        return (supportCodeDefinition) => {
+            let library = origLibrary(supportCodeDefinition)
+            library.setDefaultTimeout(this.cucumberOpts.timeout)
+            return library
         }
     }
 


### PR DESCRIPTION
this fixes #24
the ast tree walker was removed by cucumber and has been refactored into the library class instead