### PR TITLE
feat: add option to fail ambiguous step definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,24 @@ Type: `String[]`<br>
 Default: `[]`
 
 ### timeout
-Timeout for step definitions.
+Timeout in milliseconds for step definitions.
 
 Type: `Number`<br>
 Default: `30000`
+
+### ignoreUndefinedDefinitions
+**Please not that this is a wdio-cucumber-framework specifc option and not recognized by cucumber-js itself**
+Treat undefined definitions as warnings.
+
+Type: `Boolean`<br>
+Default: `false`
+
+### failAmbiguousDefinitions
+**Please not that this is a wdio-cucumber-framework specifc option and not recognized by cucumber-js itself**
+Treat ambiguous definitions as errors.
+
+Type: `Boolean`<br>
+Default: `false`
 
 ----
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -24,9 +24,9 @@ const DEFAULT_OPTS = {
     profile: [], // <string> (name) specify the profile to use
     require: [], // <string> (file/dir) require files before executing features
     snippetSyntax: undefined, // <string> specify a custom snippet syntax
-    strict: false, // fail if there are any undefined or pending steps
+    strict: false, // <boolean> fail if there are any undefined or pending steps
     tags: [], // <string[]> (expression) only execute the features or scenarios with tags matching the expression
-    timeout: DEFAULT_TIMEOUT // timeout for step definitions
+    timeout: DEFAULT_TIMEOUT // <number> timeout for step definitions in milliseconds
 }
 
 /**
@@ -48,7 +48,8 @@ class CucumberAdapter {
     async run () {
         let reporterOptions = {
             capabilities: this.capabilities,
-            ignoreUndefinedDefinitions: !!this.cucumberOpts.ignoreUndefinedDefinitions
+            ignoreUndefinedDefinitions: Boolean(this.cucumberOpts.ignoreUndefinedDefinitions),
+            failAmbiguousDefinitions: Boolean(this.cucumberOpts.failAmbiguousDefinitions)
         }
 
         wrapCommands(global.browser, this.config.beforeCommand, this.config.afterCommand)

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -83,6 +83,7 @@ class CucumberReporter {
             break
         case Cucumber.Status.PENDING:
         case Cucumber.Status.SKIPPED:
+        case Cucumber.Status.AMBIGUOUS:
             e = 'pending'
         }
         let error = {}
@@ -112,7 +113,7 @@ class CucumberReporter {
                 error = {
                     message: `Step "${stepTitle}" is not defined. You can ignore this error by setting
                               cucumberOpts.ignoreUndefinedDefinitions as true.`,
-                    stack: step.getUri() + ':' + step.getLine()
+                    stack: `${step.getUri()}:${step.getLine()}`
                 }
             }
         } else if (stepResult.getStatus() === Cucumber.Status.FAILED) {
@@ -126,6 +127,13 @@ class CucumberReporter {
                 stack: err.stack
             }
             this.failedCount++
+        } else if (stepResult.getStatus() === Cucumber.Status.AMBIGUOUS && this.options.failAmbiguousDefinitions) {
+            e = 'fail'
+            this.failedCount++
+            error = {
+                message: `Step "${stepTitle}" is ambiguous. The following steps matched the step definition`,
+                stack: stepResult.getAmbiguousStepDefinitions().map(step => `${step.getPattern().toString()} in ${step.getUri()}:${step.getLine()}`).join('\n')
+            }
         }
 
         this.emit('test:' + e, {


### PR DESCRIPTION
This adds the possibility to fail ambiguous step definitions instead of just skipping them. It's false per default.

An example use case is to force the developers to update their step definitions, without enabling strict mode since pending steps might be OK due to the fact that some parts of the tests can not be implemented right now.