### PR TITLE
Split pending and skipped tests

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -82,9 +82,12 @@ class CucumberReporter {
             e = 'pass'
             break
         case Cucumber.Status.PENDING:
+            e = 'pending'
+            break
         case Cucumber.Status.SKIPPED:
         case Cucumber.Status.AMBIGUOUS:
-            e = 'pending'
+            e = 'skipped'
+            break
         }
         let error = {}
         let stepTitle = step.getName() || step.getKeyword() || 'Undefined Step'

--- a/test/fixtures/steps-status-step-definitions.js
+++ b/test/fixtures/steps-status-step-definitions.js
@@ -1,0 +1,13 @@
+var assert = require('assert')
+
+module.exports = function () {
+    this.Given(/Test will fail/, (url) => {
+        return assert.ok(false, 'expected failure')
+    })
+
+    this.Given('Pending test', () => 'pending')
+
+    this.Then(/this step will be skipped/, (selector) => {
+        throw new Error('unexpected error')
+    })
+}

--- a/test/fixtures/steps-status.conf.js
+++ b/test/fixtures/steps-status.conf.js
@@ -1,0 +1,11 @@
+export default {
+    sync: false,
+    capabilities: {
+        browserName: 'chrome'
+    },
+
+    cucumberOpts: {
+        timeout: 5000,
+        require: [__dirname + '/steps-status-step-definitions.js']
+    }
+}

--- a/test/fixtures/steps-status.feature
+++ b/test/fixtures/steps-status.feature
@@ -1,0 +1,9 @@
+Feature: Steps status
+
+  Scenario: Failing test
+    Given Test will fail
+    And this step will be skipped
+    Then this step will be skipped
+
+  Scenario: Pending
+    Given Pending test

--- a/test/steps.spec.js
+++ b/test/steps.spec.js
@@ -1,0 +1,44 @@
+import { CucumberAdapter } from '../lib/adapter'
+import CucumberReporter from '../lib/reporter'
+import config from './fixtures/steps-status.conf'
+
+const specs = ['./test/fixtures/steps-status.feature']
+
+const WebdriverIO = class {}
+
+describe('steps', () => {
+    it('should report different status for steps', async () => {
+        const messages = []
+        const send = CucumberReporter.prototype.send
+        CucumberReporter.prototype.send = message => messages.push(message)
+        global.browser = new WebdriverIO()
+        global.browser.options = config
+        const adapter = new CucumberAdapter(0, config, specs, {})
+
+        ;(await adapter.run()).should.be.equal(1)
+
+        messages.map(msg => msg.event).should.be.deepEqual([
+            'suite:start',
+
+            // failed
+            'suite:start',
+            'test:start',
+            'test:fail',
+            'test:start',
+            'test:skipped',
+            'test:start',
+            'test:skipped',
+            'suite:end',
+
+            // pending
+            'suite:start',
+            'test:start',
+            'test:pending',
+            'suite:end',
+
+            'suite:end'
+        ])
+
+        CucumberReporter.prototype.send = send
+    })
+})


### PR DESCRIPTION
This is a first step to fix https://github.com/webdriverio/wdio-allure-reporter/issues/26

Now skipped tests will be reported with `skipped` status. The `pending` status is still there for really pending tests (tests with empty implementation).

