### PR TITLE
Changed the emit call to add a UID for suite, scenario & step definition

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -29,7 +29,7 @@ class CucumberReporter {
         this.runningFeature = feature
 
         this.emit('suite:start', {
-            uid: this.getUniqueId(feature),
+            uid: this.getUniqueIdentifier(feature),
             title: feature.getName(),
             type: 'suite',
             file: this.getUriOf(feature)
@@ -45,9 +45,9 @@ class CucumberReporter {
         this.testStart = new Date()
 
         this.emit('suite:start', {
-            uid: this.getUniqueId(scenario),
+            uid: this.getUniqueIdentifier(scenario),
             title: scenario.getName(),
-            parent: this.getUniqueId(this.runningFeature),
+            parent: this.getUniqueIdentifier(this.runningFeature),
             type: 'suite',
             file: this.getUriOf(scenario)
         })
@@ -60,11 +60,11 @@ class CucumberReporter {
         this.testStart = new Date()
 
         this.emit('test:start', {
-            uid: this.getUniqueId(step),
+            uid: this.getUniqueIdentifier(step),
             title: step.getName(),
             type: 'test',
             file: step.getUri(),
-            parent: this.getUniqueId(this.runningScenario),
+            parent: this.getUniqueIdentifier(this.runningScenario),
             duration: new Date() - this.testStart
         })
 
@@ -140,11 +140,11 @@ class CucumberReporter {
         }
 
         this.emit('test:' + e, {
-            uid: this.getUniqueId(step),
+            uid: this.getUniqueIdentifier(step),
             title: stepTitle.trim(),
             type: 'test',
             file: this.getUriOf(step),
-            parent: this.getUniqueId(this.runningScenario),
+            parent: this.getUniqueIdentifier(this.runningScenario),
             error: error,
             duration: new Date() - this.testStart
         })
@@ -155,9 +155,9 @@ class CucumberReporter {
     handleAfterScenarioEvent (event, callback) {
         const scenario = event.getUri ? event : event.getPayloadItem('scenario')
         this.emit('suite:end', {
-            uid: this.getUniqueId(scenario),
+            uid: this.getUniqueIdentifier(scenario),
             title: scenario.getName(),
-            parent: this.getUniqueId(this.runningFeature),
+            parent: this.getUniqueIdentifier(this.runningFeature),
             type: 'suite',
             file: this.getUriOf(scenario),
             duration: new Date() - this.scenarioStart
@@ -169,7 +169,7 @@ class CucumberReporter {
     handleAfterFeatureEvent (event, callback) {
         const feature = event.getUri ? event : event.getPayloadItem('feature')
         this.emit('suite:end', {
-            uid: this.getUniqueId(feature),
+            uid: this.getUniqueIdentifier(feature),
             title: feature.getName(),
             type: 'suite',
             file: this.getUriOf(feature),
@@ -183,7 +183,7 @@ class CucumberReporter {
         let message = {
             event: event,
             cid: this.cid,
-            uid: this.getUniqueId(payload),
+            uid: this.getUniqueIdentifier(payload),
             title: payload.title,
             pending: payload.pending || false,
             parent: payload.parent || null,

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -216,7 +216,8 @@ class CucumberReporter {
     }
 
     getUniqueIdentifier (target) {
-        return target.getName() + target.getLine()
+        return target.getName() + 
+                (target.getLine() || '')
     }
 }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -183,7 +183,7 @@ class CucumberReporter {
         let message = {
             event: event,
             cid: this.cid,
-            uid: this.getUniqueIdentifier(payload),
+            uid: payload.uid,
             title: payload.title,
             pending: payload.pending || false,
             parent: payload.parent || null,

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -29,6 +29,7 @@ class CucumberReporter {
         this.runningFeature = feature
 
         this.emit('suite:start', {
+            uid: this.getUniqueId(feature),
             title: feature.getName(),
             type: 'suite',
             file: this.getUriOf(feature)
@@ -44,8 +45,9 @@ class CucumberReporter {
         this.testStart = new Date()
 
         this.emit('suite:start', {
+            uid: this.getUniqueId(scenario),
             title: scenario.getName(),
-            parent: this.runningFeature.getName(),
+            parent: this.getUniqueId(this.runningFeature),
             type: 'suite',
             file: this.getUriOf(scenario)
         })
@@ -58,10 +60,11 @@ class CucumberReporter {
         this.testStart = new Date()
 
         this.emit('test:start', {
+            uid: this.getUniqueId(step),
             title: step.getName(),
             type: 'test',
             file: step.getUri(),
-            parent: this.runningScenario.getName(),
+            parent: this.getUniqueId(this.runningScenario),
             duration: new Date() - this.testStart
         })
 
@@ -137,10 +140,11 @@ class CucumberReporter {
         }
 
         this.emit('test:' + e, {
+            uid: this.getUniqueId(step),
             title: stepTitle.trim(),
             type: 'test',
             file: this.getUriOf(step),
-            parent: this.runningScenario.getName(),
+            parent: this.getUniqueId(this.runningScenario),
             error: error,
             duration: new Date() - this.testStart
         })
@@ -151,8 +155,9 @@ class CucumberReporter {
     handleAfterScenarioEvent (event, callback) {
         const scenario = event.getUri ? event : event.getPayloadItem('scenario')
         this.emit('suite:end', {
+            uid: this.getUniqueId(scenario),
             title: scenario.getName(),
-            parent: this.runningFeature.getName(),
+            parent: this.getUniqueId(this.runningFeature),
             type: 'suite',
             file: this.getUriOf(scenario),
             duration: new Date() - this.scenarioStart
@@ -164,6 +169,7 @@ class CucumberReporter {
     handleAfterFeatureEvent (event, callback) {
         const feature = event.getUri ? event : event.getPayloadItem('feature')
         this.emit('suite:end', {
+            uid: this.getUniqueId(feature),
             title: feature.getName(),
             type: 'suite',
             file: this.getUriOf(feature),
@@ -177,6 +183,7 @@ class CucumberReporter {
         let message = {
             event: event,
             cid: this.cid,
+            uid: this.getUniqueId(payload),
             title: payload.title,
             pending: payload.pending || false,
             parent: payload.parent || null,
@@ -206,6 +213,10 @@ class CucumberReporter {
         }
 
         return type.getUri().replace(process.cwd(), '')
+    }
+
+    getUniqueIdentifier (target) {
+        return target.getName() + target.getLine();
     }
 }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -216,7 +216,7 @@ class CucumberReporter {
     }
 
     getUniqueIdentifier (target) {
-        return target.getName() + 
+        return target.getName() +
                 (target.getLine() || '')
     }
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -216,7 +216,7 @@ class CucumberReporter {
     }
 
     getUniqueIdentifier (target) {
-        return target.getName() + target.getLine();
+        return target.getName() + target.getLine()
     }
 }
 


### PR DESCRIPTION
**Please note:** this PR is required for fixing issue [#11 reported in the wdio-spec-reporter](https://github.com/webdriverio/wdio-spec-reporter/issues/11) repo, please refer to that issue for more details.

In order to identify each suite, spec & step when reporting back to the user I added a UID, which is composed from the name of the suite/spec and it's line number in the feature file. This is also done for any parent suite/spec/step so we can always use the UID to identify parents as well.

This **is** a breaking change! Since the parent will no longer be correctly reported back to the reporter class. (will now read the UID of the parent)