### PR TITLE
Add tags to names (optional)

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -22,7 +22,8 @@ const DEFAULT_OPTS = {
     snippetSyntax: undefined, // <string> specify a custom snippet syntax
     strict: false, // <boolean> fail if there are any undefined or pending steps
     tags: [], // <string[]> (expression) only execute the features or scenarios with tags matching the expression
-    timeout: DEFAULT_TIMEOUT // <number> timeout for step definitions in milliseconds
+    timeout: DEFAULT_TIMEOUT, // <number> timeout for step definitions in milliseconds
+    tagsInTitle: false // <boolean> add cucumber tags to feature or scenario name
 }
 
 /**
@@ -45,7 +46,8 @@ class CucumberAdapter {
         let reporterOptions = {
             capabilities: this.capabilities,
             ignoreUndefinedDefinitions: Boolean(this.cucumberOpts.ignoreUndefinedDefinitions),
-            failAmbiguousDefinitions: Boolean(this.cucumberOpts.failAmbiguousDefinitions)
+            failAmbiguousDefinitions: Boolean(this.cucumberOpts.failAmbiguousDefinitions),
+            tagsInTitle: Boolean(this.cucumberOpts.tagsInTitle)
         }
 
         wrapCommands(global.browser, this.config.beforeCommand, this.config.afterCommand)

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -228,7 +228,7 @@ class CucumberReporter {
 
     getTitle (featureOrScenario) {
         const name = featureOrScenario.getName()
-        const tags = featureOrScenario.getTags()
+        const tags = featureOrScenario.getTags ? featureOrScenario.getTags() : []
         if (!this.tagsInTitle || !tags.length) return name
         return `${tags.map(tag => tag.getName()).join(', ')}: ${name}`
     }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -14,6 +14,7 @@ class CucumberReporter {
     constructor (BaseListener, options, cid, specs) {
         this.listener = BaseListener
         this.capabilities = options.capabilities
+        this.tagsInTitle = options.tagsInTitle || false
         this.options = options
         this.cid = cid
         this.specs = specs
@@ -34,7 +35,7 @@ class CucumberReporter {
 
         this.emit('suite:start', {
             uid: this.getUniqueIdentifier(feature),
-            title: feature.getName(),
+            title: this.getTitle(feature),
             type: 'suite',
             file: this.getUriOf(feature)
         })
@@ -50,7 +51,7 @@ class CucumberReporter {
 
         this.emit('suite:start', {
             uid: this.getUniqueIdentifier(scenario),
-            title: scenario.getName(),
+            title: this.getTitle(scenario),
             parent: this.getUniqueIdentifier(this.runningFeature),
             type: 'suite',
             file: this.getUriOf(scenario)
@@ -223,6 +224,13 @@ class CucumberReporter {
                 resolve()
             }, 100)
         })
+    }
+
+    getTitle (featureOrScenario) {
+        const name = featureOrScenario.getName()
+        const tags = featureOrScenario.getTags()
+        if (!this.tagsInTitle || !tags.length) return name
+        return `${tags.map(tag => tag.getName()).join(', ')}: ${name}`
     }
 
     getListener () {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -228,7 +228,7 @@ class CucumberReporter {
 
     getTitle (featureOrScenario) {
         const name = featureOrScenario.getName()
-        const tags = featureOrScenario.getTags ? featureOrScenario.getTags() : []
+        const tags = featureOrScenario.getTags()
         if (!this.tagsInTitle || !tags.length) return name
         return `${tags.map(tag => tag.getName()).join(', ')}: ${name}`
     }


### PR DESCRIPTION
At this moment I cannot see tags in webdriverio results.

This change will add tags before names for reporter results (for `tagsInTitle` equal true in CucumberOpts)

```
  @tag1 @tag2
  Scenario: Scenario name
    Given Foo bar
    ...
```

now we have always title: `Scenario name`

After change will have possibility to have `@tag1, @tag2: Scenario name`