### PR TITLE
fix 'undefined - no stack available' error

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -130,9 +130,16 @@ class CucumberReporter {
              * for some reasons
              */
             let err = stepResult.getFailureException()
-            error = {
-                message: err.message,
-                stack: err.stack
+            if (typeof err === 'string') {
+                error = {
+                    message: err,
+                    stack: ''
+                }
+            } else if (err instanceof Error) {
+                error = {
+                    message: err.message,
+                    stack: err.stack
+                }
             }
             this.failedCount++
         } else if (stepResult.getStatus() === Cucumber.Status.AMBIGUOUS && this.options.failAmbiguousDefinitions) {


### PR DESCRIPTION
cucumber may send string errors instead of full error objects
this ensures we always print the error string
see https://github.com/webdriverio/webdriverio/issues/2093