### PR TITLE
fix: undefined error for reporting

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -130,9 +130,16 @@ class CucumberReporter {
              * for some reasons
              */
             let err = stepResult.getFailureException()
-            error = {
-                message: err.message,
-                stack: err.stack
+            if (typeof err === 'string') {
+                error = {
+                    message: err,
+                    stack: ''
+                }
+            } else if (err instanceof Error) {
+                error = {
+                    message: err.message,
+                    stack: err.stack
+                }
             }
             this.failedCount++
         } else if (stepResult.getStatus() === Cucumber.Status.AMBIGUOUS && this.options.failAmbiguousDefinitions) {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -130,15 +130,14 @@ class CucumberReporter {
              * for some reasons
              */
             let err = stepResult.getFailureException()
-            if (typeof err === 'string') {
-                error = {
-                    message: err,
-                    stack: ''
-                }
-            } else if (err instanceof Error) {
+            if (err instanceof Error) {
                 error = {
                     message: err.message,
                     stack: err.stack
+                }
+            } else {
+                error = {
+                    message: err
                 }
             }
             this.failedCount++


### PR DESCRIPTION
This is @Kignuf #58 PR with added tests. Solves the problem of Cucumber returning a string as an error message.

Resolves #58 & #52.

Resolves https://github.com/webdriverio/webdriverio/issues/2093.