### PR TITLE
Clarify new require behaviour since v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ Type: `String[]`<br>
 Default: `[]`
 
 ### require
-Require files/dir before executing features. If you apply a path don't use globbing as it is not supported by Cucumber. Instead just reference the directory where you step definitions are located (e.g. `/path/to/definitions` instead of `/path/to/definitions/*`).
+**Please note that globbing is not supported by Cucumber, paths must adhere to Node module resolution**
+Require files before executing features (e.g. `/path/to/module` or `/path/to/module-directory` where directory contains `index.js`).
 
 Type: `String[]`<br>
 Default: `[]`


### PR DESCRIPTION
As mentioned in https://github.com/webdriverio/wdio-cucumber-framework/issues/71 this commit clarifies the new `require` config behaviour.

This commit in `cucumber` appears to have changed it:
https://github.com/cucumber/cucumber-js/commit/2d7c2523ddd88153a45d86f0e0f2a50c16814d1f

According to the commit above, automatic loading of `*.js` files below `./features` will still happen if the `require` config isn't set.