### PR TITLE
Expose tags in events

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -37,7 +37,8 @@ class CucumberReporter {
             uid: this.getUniqueIdentifier(feature),
             title: this.getTitle(feature),
             type: 'suite',
-            file: this.getUriOf(feature)
+            file: this.getUriOf(feature),
+            tags: feature.tags
         })
 
         process.nextTick(callback)
@@ -54,7 +55,8 @@ class CucumberReporter {
             title: this.getTitle(scenario),
             parent: this.getUniqueIdentifier(this.runningFeature),
             type: 'suite',
-            file: this.getUriOf(scenario)
+            file: this.getUriOf(scenario),
+            tags: scenario.tags
         })
 
         process.nextTick(callback)
@@ -70,7 +72,8 @@ class CucumberReporter {
             type: 'test',
             file: step.uri,
             parent: this.getUniqueIdentifier(this.runningScenario),
-            duration: new Date() - this.testStart
+            duration: new Date() - this.testStart,
+            tags: this.runningScenario.tags
         })
 
         process.nextTick(callback)
@@ -156,7 +159,8 @@ class CucumberReporter {
             file: this.getUriOf(step),
             parent: this.getUniqueIdentifier(this.runningScenario),
             error: error,
-            duration: new Date() - this.testStart
+            duration: new Date() - this.testStart,
+            tags: this.runningScenario.tags
         })
 
         process.nextTick(callback)
@@ -170,7 +174,8 @@ class CucumberReporter {
             parent: this.getUniqueIdentifier(this.runningFeature),
             type: 'suite',
             file: this.getUriOf(scenario),
-            duration: new Date() - this.scenarioStart
+            duration: new Date() - this.scenarioStart,
+            tags: scenario.tags
         })
 
         process.nextTick(callback)
@@ -183,7 +188,8 @@ class CucumberReporter {
             title: feature.name,
             type: 'suite',
             file: this.getUriOf(feature),
-            duration: new Date() - this.featureStart
+            duration: new Date() - this.featureStart,
+            tags: feature.tags
         })
 
         process.nextTick(callback)
@@ -202,7 +208,8 @@ class CucumberReporter {
             err: payload.error || {},
             duration: payload.duration,
             runner: {},
-            specs: this.specs
+            specs: this.specs,
+            tags: payload.tags || []
         }
 
         message.runner[this.cid] = this.capabilities

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -30,31 +30,33 @@ describe('cucumber reporter', () => {
 
     describe('emits messages for certain cucumber events', () => {
         it('should send proper data on handleBeforeFeatureEvent', () => {
-            reporter.handleBeforeFeature(getEvent('feature', 'pass', 123), NOOP)
+            reporter.handleBeforeFeature(getEvent('feature', 'pass', 123, ['abc']), NOOP)
 
             send.calledWithMatch({
                 event: 'suite:start',
                 type: 'suite',
                 uid: 'feature123',
                 file: 'foobar2',
-                cid: '0-1'
+                cid: '0-1',
+                tags: ['abc']
             }).should.be.true()
         })
 
         it('should send proper data on handleBeforeScenarioEvent', () => {
-            reporter.handleBeforeScenario(getEvent('scenario', 'pass', 124), NOOP)
+            reporter.handleBeforeScenario(getEvent('scenario', 'pass', 124, ['abc']), NOOP)
             send.calledWithMatch({
                 event: 'suite:start',
                 type: 'suite',
                 cid: '0-1',
                 parent: 'feature123',
                 uid: 'scenario124',
-                file: 'foobar2'
+                file: 'foobar2',
+                tags: ['abc']
             }).should.be.true()
         })
 
         it('should send proper data on handleBeforeStepEvent', () => {
-            reporter.handleBeforeStep(getEvent('step', 'fail', 125), NOOP)
+            reporter.handleBeforeStep(getEvent('step', 'fail', 125, ['abc']), NOOP)
             send.calledWithMatch({
                 event: 'test:start',
                 type: 'test',
@@ -63,12 +65,13 @@ describe('cucumber reporter', () => {
                 parent: 'scenario124',
                 uid: 'step125',
                 file: 'foobar2',
-                duration: 0
+                duration: 0,
+                tags: ['abc']
             }).should.be.true()
         })
 
         it('should send proper data on handleStepResultEvent for error of error type', () => {
-            reporter.handleStepResult(getEvent('step', 'failed', 126), NOOP)
+            reporter.handleStepResult(getEvent('step', 'failed', 126, ['abc']), NOOP)
             send.calledWithMatch({
                 event: 'test:fail',
                 type: 'test',
@@ -76,13 +79,14 @@ describe('cucumber reporter', () => {
                 cid: '0-1',
                 parent: 'scenario124',
                 uid: 'step126',
-                file: 'foobar2'
+                file: 'foobar2',
+                tags: ['abc']
             }).should.be.true()
             send.args[send.args.length - 1][0].err.message.should.be.equal('foobar-error')
         })
 
         it('should send proper data on handleStepResultEvent for error of string type', () => {
-            reporter.handleStepResult(getEvent('step', 'failed', 126, [], 'foo-error'), NOOP)
+            reporter.handleStepResult(getEvent('step', 'failed', 126, ['abc'], 'foo-error'), NOOP)
             send.calledWithMatch({
                 event: 'test:fail',
                 type: 'test',
@@ -90,25 +94,27 @@ describe('cucumber reporter', () => {
                 cid: '0-1',
                 parent: 'scenario124',
                 uid: 'step126',
-                file: 'foobar2'
+                file: 'foobar2',
+                tags: ['abc']
             }).should.be.true()
             send.args[send.args.length - 1][0].err.message.should.be.equal('foo-error')
         })
 
         it('should send proper data on handleAfterScenarioEvent', () => {
-            reporter.handleAfterScenario(getEvent('scenario', null, 127), NOOP)
+            reporter.handleAfterScenario(getEvent('scenario', null, 127, ['abc']), NOOP)
             send.calledWithMatch({
                 event: 'suite:end',
                 type: 'suite',
                 cid: '0-1',
                 parent: 'feature123',
                 uid: 'scenario127',
-                file: 'foobar2'
+                file: 'foobar2',
+                tags: ['abc']
             }).should.be.true()
         })
 
         it('should send proper data on handleAfterFeatureEvent', () => {
-            reporter.handleAfterFeature(getEvent('feature', null, 128), NOOP)
+            reporter.handleAfterFeature(getEvent('feature', null, 128, ['abc']), NOOP)
             send.calledWithMatch({
                 event: 'suite:end',
                 type: 'suite',
@@ -116,7 +122,8 @@ describe('cucumber reporter', () => {
                 file: 'foobar2',
                 uid: 'feature128',
                 cid: '0-1',
-                parent: null
+                parent: null,
+                tags: ['abc']
             }).should.be.true()
         })
     })

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -38,7 +38,9 @@ describe('cucumber reporter', () => {
                 uid: 'feature123',
                 file: 'foobar2',
                 cid: '0-1',
-                tags: ['abc']
+                tags: [{
+                    name: 'abc'
+                }]
             }).should.be.true()
         })
 
@@ -51,7 +53,9 @@ describe('cucumber reporter', () => {
                 parent: 'feature123',
                 uid: 'scenario124',
                 file: 'foobar2',
-                tags: ['abc']
+                tags: [{
+                    name: 'abc'
+                }]
             }).should.be.true()
         })
 
@@ -66,7 +70,9 @@ describe('cucumber reporter', () => {
                 uid: 'step125',
                 file: 'foobar2',
                 duration: 0,
-                tags: ['abc']
+                tags: [{
+                    name: 'abc'
+                }]
             }).should.be.true()
         })
 
@@ -80,7 +86,9 @@ describe('cucumber reporter', () => {
                 parent: 'scenario124',
                 uid: 'step126',
                 file: 'foobar2',
-                tags: ['abc']
+                tags: [{
+                    name: 'abc'
+                }]
             }).should.be.true()
             send.args[send.args.length - 1][0].err.message.should.be.equal('foobar-error')
         })
@@ -95,7 +103,9 @@ describe('cucumber reporter', () => {
                 parent: 'scenario124',
                 uid: 'step126',
                 file: 'foobar2',
-                tags: ['abc']
+                tags: [{
+                    name: 'abc'
+                }]
             }).should.be.true()
             send.args[send.args.length - 1][0].err.message.should.be.equal('foo-error')
         })
@@ -109,7 +119,9 @@ describe('cucumber reporter', () => {
                 parent: 'feature123',
                 uid: 'scenario127',
                 file: 'foobar2',
-                tags: ['abc']
+                tags: [{
+                    name: 'abc'
+                }]
             }).should.be.true()
         })
 
@@ -123,7 +135,9 @@ describe('cucumber reporter', () => {
                 uid: 'feature128',
                 cid: '0-1',
                 parent: null,
-                tags: ['abc']
+                tags: [{
+                    name: 'abc'
+                }]
             }).should.be.true()
         })
     })


### PR DESCRIPTION
Fixes part of https://github.com/webdriverio/wdio-cucumber-framework/issues/74

Exposes the applicable tags in the events that are emitted to be handled by reporters