### PR TITLE
Steps can't use callbacks - Wrap them only if necessary

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -123,8 +123,12 @@ class CucumberAdapter {
     wrapSteps () {
         Cucumber.defineSupportCode(({setDefinitionFunctionWrapper}) => {
             setDefinitionFunctionWrapper((fn, options = {}) => {
-                let retryTest = isFinite(options.retry) ? parseInt(options.retry, 10) : 0
-                let wrappedFunction = fn.name === 'async' || this.config.sync === false
+                if (!isFinite(options.retry)) {
+                    return fn
+                }
+
+                const retryTest = parseInt(options.retry, 10)
+                const wrappedFunction = fn.name === 'async' || this.config.sync === false
                     ? this.wrapStepAsync(fn, retryTest) : this.wrapStepSync(fn, retryTest)
                 return wrappedFunction
             })


### PR DESCRIPTION
Wrapping steps which use callbacks instead of returning promises leads to this cucumber error:
**"function uses multiple asynchronous interfaces: callback and promise"**

This is causing by the `setDefinitionFunctionWrapper` which always returns a promise. We can't predict with its function that the steps use promise or not.

I suggest not to wrap the step if `retry` option is not given as a first work around.

Is there any problem of not calling wdio-sync functions though ?
