### PR TITLE
Add feature/scenario name to test:start event

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -73,7 +73,9 @@ class CucumberReporter {
             file: step.uri,
             parent: this.getUniqueIdentifier(this.runningScenario),
             duration: new Date() - this.testStart,
-            tags: this.runningScenario.tags
+            tags: this.runningScenario.tags,
+            featureName: this.runningFeature.name,
+            scenarioName: this.runningScenario.name
         })
 
         process.nextTick(callback)
@@ -209,7 +211,9 @@ class CucumberReporter {
             duration: payload.duration,
             runner: {},
             specs: this.specs,
-            tags: payload.tags || []
+            tags: payload.tags || [],
+            featureName: payload.featureName,
+            scenarioName: payload.scenarioName
         }
 
         message.runner[this.cid] = this.capabilities

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -72,7 +72,9 @@ describe('cucumber reporter', () => {
                 duration: 0,
                 tags: [{
                     name: 'abc'
-                }]
+                }],
+                featureName: 'feature',
+                scenarioName: 'scenario'
             }).should.be.true()
         })
 


### PR DESCRIPTION
Adds the current feature and scenario name for a test, so they can be used by formatters: webdriverio/wdio-allure-reporter#87