### PR TITLE
 Fix #105 Reporters fails on running cucumber before\after hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+.idea

--- a/lib/cucumberEventListener.js
+++ b/lib/cucumberEventListener.js
@@ -10,6 +10,7 @@ export class CucumberEventListener extends EventEmitter {
         eventBroadcaster
             .on('gherkin-document', this.onGherkinDocument.bind(this))
             .on('pickle-accepted', this.onPickleAccepted.bind(this))
+            .on('test-case-prepared', this.onTestStepPrepared.bind(this))
             .on('test-step-started', this.onTestStepStarted.bind(this))
             .on('test-step-finished', this.onTestStepFinished.bind(this))
             .on('test-case-finished', this.onTestCaseFinished.bind(this))
@@ -97,6 +98,41 @@ export class CucumberEventListener extends EventEmitter {
         const step = scenario.steps[testStepStartedEvent.index]
 
         this.emit('before-step', uri, feature, scenario, step)
+    }
+
+    // testStepPreparedEvent = {
+    //     sourceLocation: { uri: string, line: 0 }
+    //     steps: [
+    //         {
+    //             actionLocation: {
+    //                 uri: string
+    //                 line: 0
+    //             }
+    //         }
+    //     ]
+    // }
+    onTestStepPrepared (testStepPreparedEvent) {
+        const sourceLocation = testStepPreparedEvent.sourceLocation
+        const uri = sourceLocation.uri
+
+        const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
+        const scenario = doc.feature.children.find(child => child.location.line === sourceLocation.line)
+        const scenarioHasHooks = scenario.steps.filter((step) => step.type === 'Hook').length > 0
+        if (scenarioHasHooks) {
+            return
+        }
+        const allSteps = testStepPreparedEvent.steps
+        allSteps.forEach((step, idx) => {
+            if (!step.sourceLocation) {
+                const hook = {
+                    type: 'Hook',
+                    location: { line: step.actionLocation.line, column: 0, uri: step.actionLocation.uri },
+                    keyword: 'Hook',
+                    text: ''
+                }
+                scenario.steps.splice(idx, 0, hook)
+            }
+        })
     }
 
     // testStepFinishedEvent = {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,5 +1,6 @@
 import { Status } from 'cucumber'
 import { CucumberEventListener } from './cucumberEventListener'
+import * as path from 'path'
 
 const SETTLE_TIMEOUT = 5000
 
@@ -234,6 +235,13 @@ class CucumberReporter {
     }
 
     getUniqueIdentifier (target) {
+        if (target.type === 'Hook') {
+            const name = path.basename(target.location.uri)
+            const line = target.location.line
+
+            return name + line
+        }
+
         const name = target.name || target.text
         const location = target.location || target.locations[0]
         const line = (location && location.line) || ''

--- a/test/cucumber-hooks.spec.js
+++ b/test/cucumber-hooks.spec.js
@@ -1,0 +1,44 @@
+import { CucumberAdapter } from '../lib/adapter'
+import configNativePromises from './fixtures/cucumber-hooks.conf'
+const specs = ['./test/fixtures/sample.feature']
+
+const NOOP = () => {}
+
+const WebdriverIO = class {}
+WebdriverIO.prototype = {
+    /**
+     * task of this command is to add 1 so we can have a simple demo test like
+     * browser.command(1).should.be.equal(2)
+     */
+    url: () => new Promise((resolve) => {
+        setTimeout(() => resolve(), 100)
+    }),
+    click: () => new Promise((resolve) => {
+        setTimeout(() => resolve(), 100)
+    }),
+    getTitle: (ms = 100) => new Promise((resolve) => {
+        setTimeout(() => resolve('Google'), ms)
+    }),
+    pause: (ms = 100) => new Promise((resolve) => {
+        setTimeout(() => resolve(), ms)
+    }),
+    addCommand: (name, fn) => {
+        WebdriverIO.prototype[name] = fn
+    }
+}
+
+process.send = NOOP
+
+describe('Executes feature files with cucumber hooks', () => {
+    it('should get executed', async () => {
+        global.browser = new WebdriverIO()
+        global.browser.options = {}
+        const adapter = new CucumberAdapter(0, configNativePromises, specs, configNativePromises.capabilities)
+        global.browser.getPrototype = () => WebdriverIO.prototype;
+        (await adapter.run()).should.be.equal(0, 'actual test failed')
+    })
+
+    after(() => {
+        delete global.browser
+    })
+})

--- a/test/fixtures/cucumber-hooks.conf.js
+++ b/test/fixtures/cucumber-hooks.conf.js
@@ -1,0 +1,27 @@
+import path from 'path'
+
+const NOOP = () => {}
+
+export default {
+    capabilities: {
+        browserName: 'chrome'
+    },
+
+    cucumberOpts: {
+        timeout: 5000,
+        require: [path.join(__dirname, '/step-definition-with-cucumber-hooks.js')]
+    },
+
+    onPrepare: NOOP,
+    before: NOOP,
+    beforeSuite: NOOP,
+    beforeHook: NOOP,
+    afterHook: NOOP,
+    beforeTest: NOOP,
+    beforeCommand: NOOP,
+    afterCommand: NOOP,
+    afterTest: NOOP,
+    afterSuite: NOOP,
+    after: NOOP,
+    onComplete: NOOP
+}

--- a/test/fixtures/step-definition-with-cucumber-hooks.js
+++ b/test/fixtures/step-definition-with-cucumber-hooks.js
@@ -1,0 +1,48 @@
+const assert = require('assert')
+const {Given, Then, Before, BeforeAll, After, AfterAll} = require('cucumber')
+
+global.syncAsync = {}
+
+Given('I go on the website {string}', async (url) => {
+    await browser.url(url)
+})
+
+Then('I click on link {string}', async (selector) => {
+    await browser.click(selector)
+})
+
+Then('should the title of the page be {string}', async (expectedTitle) => {
+    assert.equal(await browser.getTitle(), expectedTitle)
+})
+
+Given('I go on the website {string} the async way', async (url) => {
+    await browser.url(url)
+})
+
+Then('I click on link {string} the async way', async (selector) => {
+    await browser.click(selector)
+})
+
+Then('should the title of the page be {string} the async way', async (expectedTitle) => {
+    const title = await browser.getTitle()
+    assert.equal(title, expectedTitle)
+})
+BeforeAll(() => {
+    assert.equal(true, true)
+})
+
+Before(() => {
+    assert.equal(true, true)
+})
+
+Before('@test', () => {
+    assert.equal(true, true)
+})
+
+After(() => {
+    assert.equal(true, true)
+})
+
+AfterAll(() => {
+    assert.equal(true, true)
+})


### PR DESCRIPTION
Add cucumber hooks steps to scenario steps in `cucumberEventListener.js` and report them.