### PR TITLE
Fixes to cucumber step identification

### DIFF
--- a/lib/cucumberEventListener.js
+++ b/lib/cucumberEventListener.js
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events'
 
 export class CucumberEventListener extends EventEmitter {
     gherkinDocEvents = []
+    testCasePreparedEvents = []
 
     constructor (eventBroadcaster) {
         super()
@@ -10,7 +11,7 @@ export class CucumberEventListener extends EventEmitter {
         eventBroadcaster
             .on('gherkin-document', this.onGherkinDocument.bind(this))
             .on('pickle-accepted', this.onPickleAccepted.bind(this))
-            .on('test-case-prepared', this.onTestStepPrepared.bind(this))
+            .on('test-case-prepared', this.onTestCasePrepared.bind(this))
             .on('test-step-started', this.onTestStepStarted.bind(this))
             .on('test-step-finished', this.onTestStepFinished.bind(this))
             .on('test-case-finished', this.onTestCaseFinished.bind(this))
@@ -95,12 +96,15 @@ export class CucumberEventListener extends EventEmitter {
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
         const scenario = doc.feature.children.find(child => child.location.line === sourceLocation.line)
-        const step = scenario.steps[testStepStartedEvent.index]
+        const preparedTestCase = this.testCasePreparedEvents.find( tcpe => tcpe.sourceLocation.uri === uri && tcpe.sourceLocation.line === sourceLocation.line )
+        const preparedTestCaseStep = preparedTestCase.steps[testStepStartedEvent.index]
+        const allSteps = feature.children.map( child => child.steps ).reduce( ( list, childSteps ) => list.concat( childSteps ), [] )
+        const step = allSteps.find( childStep => childStep.location.line === preparedTestCaseStep.sourceLocation.line )
 
         this.emit('before-step', uri, feature, scenario, step)
     }
 
-    // testStepPreparedEvent = {
+    // testCasePreparedEvent = {
     //     sourceLocation: { uri: string, line: 0 }
     //     steps: [
     //         {
@@ -111,8 +115,9 @@ export class CucumberEventListener extends EventEmitter {
     //         }
     //     ]
     // }
-    onTestStepPrepared (testStepPreparedEvent) {
-        const sourceLocation = testStepPreparedEvent.sourceLocation
+    onTestCasePrepared (testCasePreparedEvent) {
+        this.testCasePreparedEvents.push(testCasePreparedEvent);
+        const sourceLocation = testCasePreparedEvent.sourceLocation
         const uri = sourceLocation.uri
 
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
@@ -121,12 +126,13 @@ export class CucumberEventListener extends EventEmitter {
         if (scenarioHasHooks) {
             return
         }
-        const allSteps = testStepPreparedEvent.steps
+        const allSteps = testCasePreparedEvent.steps
         allSteps.forEach((step, idx) => {
             if (!step.sourceLocation) {
+                step.sourceLocation = { line: step.actionLocation.line, column: 0, uri: step.actionLocation.uri };
                 const hook = {
                     type: 'Hook',
-                    location: { line: step.actionLocation.line, column: 0, uri: step.actionLocation.uri },
+                    location: step.sourceLocation,
                     keyword: 'Hook',
                     text: ''
                 }
@@ -149,7 +155,10 @@ export class CucumberEventListener extends EventEmitter {
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
         const scenario = doc.feature.children.find(child => child.location.line === sourceLocation.line)
-        const step = scenario.steps[testStepFinishedEvent.index]
+        const preparedTestCase = this.testCasePreparedEvents.find( tcpe => tcpe.sourceLocation.uri === uri && tcpe.sourceLocation.line === sourceLocation.line )
+        const preparedTestCaseStep = preparedTestCase.steps[testStepFinishedEvent.index]
+        const allSteps = feature.children.map( child => child.steps ).reduce( ( list, childSteps ) => list.concat( childSteps ), [] )
+        const step = allSteps.find( childStep => childStep.location.line === preparedTestCaseStep.sourceLocation.line )
         const result = testStepFinishedEvent.result
 
         this.emit('after-step', uri, feature, scenario, step, result)

--- a/test/fixtures/sample.feature
+++ b/test/fixtures/sample.feature
@@ -3,7 +3,13 @@ Feature: Example feature
   I should pass
   to get get published
 
-  Scenario: Foo Bar
+  Background: Some repeated setup
     Given I go on the website "http://webdriver.io"
+
+  Scenario: Foo Bar
     When  I click on link "=Google"
+    Then  should the title of the page be "Google"
+
+  Scenario: Foo Baz
+    When  I click on link "=Also Google"
     Then  should the title of the page be "Google"

--- a/test/hooks.spec.js
+++ b/test/hooks.spec.js
@@ -106,7 +106,7 @@ describe('CucumberAdapter executes hooks using native Promises', () => {
 
         it('should contain right scenario data', () => {
             let scenario = beforeScenarioHook.args[0]
-            scenario.name.should.be.equal('Foo Bar')
+            scenario.name.should.be.equal('Foo Baz')
         })
     })
 
@@ -215,7 +215,7 @@ describe('CucumberAdapter executes hooks using native Promises', () => {
 
         it('should contain right scenario data', () => {
             let scenario = afterScenarioHook.args[0]
-            scenario.name.should.be.equal('Foo Bar')
+            scenario.name.should.be.equal('Foo Baz')
         })
     })
 

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -20,22 +20,34 @@ const gherkinDocEvent = {
             keyword: 'Feature',
             name: 'feature',
             children: [{
+                type: 'Background',
+                location: { line: 124, column: 0 },
+                keyword: 'Background',
+                name: 'background',
+                steps: [
+                    {
+                        location: { line: 125, column: 1 },
+                        keyword: 'Given ',
+                        text: 'background-title'
+                    }
+                ]
+            }, {
                 type: 'Scenario',
                 tags: [
                     { name: '@scenario-tag1' },
                     { name: '@scenario-tag2' }
                 ],
-                location: { line: 124, column: 0 },
+                location: { line: 126, column: 0 },
                 keyword: 'Scenario',
                 name: 'scenario',
                 steps: [
                     {
-                        location: { line: 125, column: 1 },
+                        location: { line: 127, column: 1 },
                         keyword: 'Given ',
                         text: 'step-title-passing'
                     },
                     {
-                        location: { line: 126, column: 1 },
+                        location: { line: 128, column: 1 },
                         keyword: 'When ',
                         text: 'step-title-failing'
                     }
@@ -79,9 +91,9 @@ describe('cucumber reporter', () => {
                 pickle: {
                     tags: [{ name: 'abc' }],
                     name: 'scenario',
-                    locations: [{ line: 124, column: 1 }],
+                    locations: [{ line: 126, column: 1 }],
                     steps: [{
-                        locations: [{ line: 125, column: 1 }],
+                        locations: [{ line: 127, column: 1 }],
                         keyword: 'Given ',
                         text: 'I go on the website "http://webdriver.io" the async way'
                     }]
@@ -93,7 +105,7 @@ describe('cucumber reporter', () => {
                 type: 'suite',
                 cid: '0-1',
                 parent: 'feature123',
-                uid: 'scenario124',
+                uid: 'scenario126',
                 file: './any.feature',
                 tags: [{ name: 'abc' }]
             })
@@ -101,12 +113,29 @@ describe('cucumber reporter', () => {
 
         it('should send proper data on `test-step-started` event', () => {
             eventBroadcaster.emit('gherkin-document', gherkinDocEvent)
+            eventBroadcaster.emit('test-case-prepared', {
+                sourceLocation: { uri: gherkinDocEvent.uri, line: 126 },
+                steps: [
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 125 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 127 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 128 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    }
+                ]
+            })
             send.reset()
 
             eventBroadcaster.emit('test-step-started', {
-                index: 0,
+                index: 1,
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 124 }
+                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
                 }
             })
 
@@ -115,8 +144,8 @@ describe('cucumber reporter', () => {
                 type: 'test',
                 title: 'step-title-passing',
                 cid: '0-1',
-                parent: 'scenario124',
-                uid: 'step-title-passing125',
+                parent: 'scenario126',
+                uid: 'step-title-passing127',
                 file: './any.feature',
                 duration: 0,
                 tags: [
@@ -130,13 +159,30 @@ describe('cucumber reporter', () => {
 
         it('should send proper data on successful `test-step-finished` event', () => {
             eventBroadcaster.emit('gherkin-document', gherkinDocEvent)
+            eventBroadcaster.emit('test-case-prepared', {
+                sourceLocation: { uri: gherkinDocEvent.uri, line: 126 },
+                steps: [
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 125 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 127 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 128 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    }
+                ]
+            })
             send.reset()
 
             eventBroadcaster.emit('test-step-finished', {
-                index: 0,
+                index: 1,
                 result: { duration: 10, status: 'passed' },
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 124 }
+                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
                 }
             })
 
@@ -145,8 +191,8 @@ describe('cucumber reporter', () => {
                 type: 'test',
                 title: 'step-title-passing',
                 cid: '0-1',
-                parent: 'scenario124',
-                uid: 'step-title-passing125',
+                parent: 'scenario126',
+                uid: 'step-title-passing127',
                 file: './any.feature',
                 tags: [
                     { name: '@scenario-tag1' },
@@ -157,17 +203,34 @@ describe('cucumber reporter', () => {
 
         it('should send proper data on failing `test-step-finished` event with exception', () => {
             eventBroadcaster.emit('gherkin-document', gherkinDocEvent)
+            eventBroadcaster.emit('test-case-prepared', {
+                sourceLocation: { uri: gherkinDocEvent.uri, line: 126 },
+                steps: [
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 125 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 127 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 128 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    }
+                ]
+            })
             send.reset()
 
             eventBroadcaster.emit('test-step-finished', {
-                index: 1,
+                index: 2,
                 result: {
                     duration: 10,
                     status: 'failed',
                     exception: new Error('exception-error')
                 },
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 124 }
+                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
                 }
             })
 
@@ -176,8 +239,8 @@ describe('cucumber reporter', () => {
                 type: 'test',
                 title: 'step-title-failing',
                 cid: '0-1',
-                parent: 'scenario124',
-                uid: 'step-title-failing126',
+                parent: 'scenario126',
+                uid: 'step-title-failing128',
                 file: './any.feature',
                 tags: [
                     { name: '@scenario-tag1' },
@@ -189,17 +252,34 @@ describe('cucumber reporter', () => {
 
         it('should send proper data on failing `test-step-finished` event with string error', () => {
             eventBroadcaster.emit('gherkin-document', gherkinDocEvent)
+            eventBroadcaster.emit('test-case-prepared', {
+                sourceLocation: { uri: gherkinDocEvent.uri, line: 126 },
+                steps: [
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 125 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 127 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 128 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    }
+                ]
+            })
             send.reset()
 
             eventBroadcaster.emit('test-step-finished', {
-                index: 1,
+                index: 2,
                 result: {
                     duration: 10,
                     status: 'failed',
                     exception: 'string-error'
                 },
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 124 }
+                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
                 }
             })
 
@@ -208,8 +288,8 @@ describe('cucumber reporter', () => {
                 type: 'test',
                 title: 'step-title-failing',
                 cid: '0-1',
-                parent: 'scenario124',
-                uid: 'step-title-failing126',
+                parent: 'scenario126',
+                uid: 'step-title-failing128',
                 file: './any.feature',
                 tags: [
                     { name: '@scenario-tag1' },
@@ -221,17 +301,34 @@ describe('cucumber reporter', () => {
 
         it('should send proper data on ambiguous `test-step-finished` event', () => {
             eventBroadcaster.emit('gherkin-document', gherkinDocEvent)
+            eventBroadcaster.emit('test-case-prepared', {
+                sourceLocation: { uri: gherkinDocEvent.uri, line: 126 },
+                steps: [
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 125 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 127 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    },
+                    {
+                        sourceLocation: { uri: gherkinDocEvent.uri, line: 128 },
+                        actionLocation: { uri: gherkinDocEvent.uri, line: 126 }
+                    }
+                ]
+            })
             send.reset()
 
             eventBroadcaster.emit('test-step-finished', {
-                index: 1,
+                index: 2,
                 result: {
                     duration: 10,
                     status: 'ambiguous',
                     exception: 'cucumber-ambiguous-error-message'
                 },
                 testCase: {
-                    sourceLocation: { uri: gherkinDocEvent.uri, line: 124 }
+                    sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
                 }
             })
 
@@ -240,8 +337,8 @@ describe('cucumber reporter', () => {
                 type: 'test',
                 title: 'step-title-failing',
                 cid: '0-1',
-                parent: 'scenario124',
-                uid: 'step-title-failing126',
+                parent: 'scenario126',
+                uid: 'step-title-failing128',
                 file: './any.feature',
                 tags: [
                     { name: '@scenario-tag1' },
@@ -257,7 +354,7 @@ describe('cucumber reporter', () => {
 
             eventBroadcaster.emit('test-case-finished', {
                 result: { duration: 0, status: 'passed' },
-                sourceLocation: { uri: gherkinDocEvent.uri, line: 124 }
+                sourceLocation: { uri: gherkinDocEvent.uri, line: 126 }
             })
 
             sinon.assert.calledWithMatch(send, {
@@ -265,7 +362,7 @@ describe('cucumber reporter', () => {
                 type: 'suite',
                 cid: '0-1',
                 parent: 'feature123',
-                uid: 'scenario124',
+                uid: 'scenario126',
                 file: './any.feature',
                 tags: [
                     { name: '@scenario-tag1' },
@@ -353,9 +450,9 @@ describe('cucumber reporter', () => {
                         { name: '@scenario-tag2' }
                     ],
                     name: 'scenario',
-                    locations: [{ line: 124, column: 1 }],
+                    locations: [{ line: 126, column: 1 }],
                     steps: [{
-                        locations: [{ line: 125, column: 1 }],
+                        locations: [{ line: 127, column: 1 }],
                         keyword: 'Given ',
                         text: 'I go on the website "http://webdriver.io" the async way'
                     }]
@@ -366,7 +463,7 @@ describe('cucumber reporter', () => {
                 event: 'suite:start',
                 type: 'suite',
                 title: '@scenario-tag1, @scenario-tag2: scenario',
-                uid: 'scenario124',
+                uid: 'scenario126',
                 file: './any.feature',
                 cid: '0-1'
             })


### PR DESCRIPTION
The cucumber reporter was showing incorrect stacktraces in situations such as when using Background steps.

In order to correct this problem, the "combined" (background + normal) set of steps for a given scenario must be stored when the TestCasePrepared event arrives from Cucumber, and then used to resolve the actual sourceLocation of the needed step, based on the index of the step being executed.

Once the sourceLocation is discovered, the actual step definition must be looked up from the gherkin feature document, rather than the scenario, because steps such as "Background" aren't contained within the current scenario's pickle.