### PR TITLE
Fix filtering for tagExpression option

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -72,7 +72,7 @@ class CucumberAdapter {
         const pickleFilter = new Cucumber.PickleFilter({
             featurePaths: this.spec,
             names: this.cucumberOpts.name,
-            tagExpression: this.cucumberOpts.tags
+            tagExpression: this.cucumberOpts.tagExpression
         })
         const testCases = await Cucumber.getTestCasesFromFilesystem({
             cwd: this.cwd,


### PR DESCRIPTION
`tagExpression` option is no longer working after change in: https://github.com/webdriverio/wdio-cucumber-framework/commit/0b7e63032f7234dfa5f6383c9762d8c7288f2d26 