### PR TITLE
Feature/enrich reporter

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -35,7 +35,9 @@ class CucumberReporter {
             title: this.getTitle(feature),
             type: 'suite',
             file: uri,
-            tags: feature.tags
+            tags: feature.tags,
+            description: feature.description,
+            keyword: feature.keyword
         })
     }
 
@@ -86,6 +88,7 @@ class CucumberReporter {
         }
         let error = {}
         let stepTitle = step.text || step.keyword || 'Undefined Step'
+        let dataTable = []
 
         /**
          * if step name is undefined we are dealing with a hook
@@ -139,6 +142,12 @@ class CucumberReporter {
             }
         }
 
+        if (step.argument && step.argument.hasOwnProperty('rows')) {
+            dataTable = [{
+                rows: step.argument.rows.map(row => ({cells: row.cells.map(cell => cell.value)}))
+            }]
+        }
+
         this.emit('test:' + e, {
             uid: this.getUniqueIdentifier(step),
             title: stepTitle.trim(),
@@ -147,7 +156,9 @@ class CucumberReporter {
             parent: this.getUniqueIdentifier(scenario),
             error: error,
             duration: new Date() - this.testStart,
-            tags: scenario.tags
+            tags: scenario.tags,
+            keyword: step.keyword,
+            argument: dataTable
         })
     }
 
@@ -192,7 +203,10 @@ class CucumberReporter {
             specs: this.specs,
             tags: payload.tags || [],
             featureName: payload.featureName,
-            scenarioName: payload.scenarioName
+            scenarioName: payload.scenarioName,
+            description: payload.description,
+            keyword: payload.keyword || null,
+            argument: payload.argument
         }
 
         this.send(message, null, {}, () => ++this.receivedMessages)

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -19,6 +19,7 @@ const gherkinDocEvent = {
             location: { line: 123, column: 1 },
             keyword: 'Feature',
             name: 'feature',
+            description: '    This is a feature description\n    Second description',
             children: [{
                 type: 'Background',
                 location: { line: 124, column: 0 },
@@ -40,13 +41,54 @@ const gherkinDocEvent = {
                 location: { line: 126, column: 0 },
                 keyword: 'Scenario',
                 name: 'scenario',
+                description: '    This should be a scenario description',
                 steps: [
                     {
-                        location: { line: 127, column: 1 },
+                        type: 'Step',
+                        location: {line: 127, column: 1},
                         keyword: 'Given ',
-                        text: 'step-title-passing'
+                        text: 'step-title-passing',
+                        argument: {
+                            type: 'DataTable',
+                            location: { line: 15, column: 13 },
+                            rows: [
+                                {
+                                    type: 'TableRow',
+                                    location: { line: 15, column: 13 },
+                                    cells: [
+                                        {
+                                            type: 'TableCell',
+                                            location: { line: 15, column: 15 },
+                                            value: 'Cucumber'
+                                        },
+                                        {
+                                            type: 'TableCell',
+                                            location: { line: 15, column: 30 },
+                                            value: 'Cucumis sativus'
+                                        }
+                                    ]
+                                },
+                                {
+                                    type: 'TableRow',
+                                    location: { line: 16, column: 13 },
+                                    cells: [
+                                        {
+                                            type: 'TableCell',
+                                            location: { line: 16, column: 15 },
+                                            value: 'Burr Gherkin'
+                                        },
+                                        {
+                                            type: 'TableCell',
+                                            location: { line: 16, column: 30 },
+                                            value: 'Cucumis anguria'
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
                     },
                     {
+                        type: 'Step',
                         location: { line: 128, column: 1 },
                         keyword: 'When ',
                         text: 'step-title-failing'


### PR DESCRIPTION
This PR adds extra data to the the events

- The `Given|When|Then` keywords
- feature descriptions
- datatable data

This makes a report look from

![image](https://user-images.githubusercontent.com/11979740/42290932-b15eec58-7fc8-11e8-9f3a-d9593850b737.png)

![image](https://user-images.githubusercontent.com/11979740/42290914-95d2e32c-7fc8-11e8-849b-37e14f921459.png)

to
![image](https://user-images.githubusercontent.com/11979740/42290943-b9e7f95a-7fc8-11e8-8551-3010994da5a1.png)

![image](https://user-images.githubusercontent.com/11979740/42290924-a5234362-7fc8-11e8-9b18-429be6bb46e9.png)

The additions can also be used and implemented in the `wdio-allure-reporter` to make it more readable