### PR TITLE
fixes issues with background steps and with scenario outlines

### DIFF
--- a/lib/cucumberEventListener.js
+++ b/lib/cucumberEventListener.js
@@ -95,20 +95,8 @@ export class CucumberEventListener extends EventEmitter {
 
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
-        const scenario = doc.feature.children.find((child) => {
-            if (child.type.indexOf('ScenarioOutline') > -1) {
-                return child.examples[0].tableBody.some(function (tableEntry) {
-                    return tableEntry.location.line === sourceLocation.line
-                })
-            } else {
-                return child.location.line === sourceLocation.line
-            }
-        })
-        let combinedSteps = []
-        feature.children.forEach(function (child) {
-            combinedSteps = combinedSteps.concat(child.steps)
-        })
-        const step = combinedSteps[testStepStartedEvent.index]
+        const scenario = feature.children.find((child) => compareScenenarioLineWithSourceLine(child, sourceLocation))
+        const step = getStepFromFeature(feature, testStepStartedEvent.index)
 
         this.emit('before-step', uri, feature, scenario, step, sourceLocation)
     }
@@ -159,20 +147,8 @@ export class CucumberEventListener extends EventEmitter {
 
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
-        const scenario = doc.feature.children.find((child) => {
-            if (child.type.indexOf('ScenarioOutline') > -1) {
-                return child.examples[0].tableBody.some(function (tableEntry) {
-                    return tableEntry.location.line === sourceLocation.line
-                })
-            } else {
-                return child.location.line === sourceLocation.line
-            }
-        })
-        let combinedSteps = []
-        feature.children.forEach(function (child) {
-            combinedSteps = combinedSteps.concat(child.steps)
-        })
-        const step = combinedSteps[testStepFinishedEvent.index]
+        const scenario = feature.children.find((child) => compareScenenarioLineWithSourceLine(child, sourceLocation))
+        const step = getStepFromFeature(feature, testStepFinishedEvent.index)
         const result = testStepFinishedEvent.result
 
         this.emit('after-step', uri, feature, scenario, step, result, sourceLocation)
@@ -188,15 +164,7 @@ export class CucumberEventListener extends EventEmitter {
 
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
-        const scenario = doc.feature.children.find((child) => {
-            if (child.type.indexOf('ScenarioOutline') > -1) {
-                return child.examples[0].tableBody.some(function (tableEntry) {
-                    return tableEntry.location.line === sourceLocation.line
-                })
-            } else {
-                return child.location.line === sourceLocation.line
-            }
-        })
+        const scenario = feature.children.find((child) => compareScenenarioLineWithSourceLine(child, sourceLocation))
 
         this.emit('after-scenario', uri, feature, scenario, sourceLocation)
     }
@@ -239,4 +207,18 @@ function attachEventLogger (eventBroadcaster) {
             console.log('\n-----' + e + ' -----\n' + JSON.stringify(x, null, 2))
         })
     })
+}
+
+function compareScenenarioLineWithSourceLine (scenario, sourceLocation) {
+    if (scenario.type.indexOf('ScenarioOutline') > -1) {
+        return scenario.examples[0].tableBody.some((tableEntry) => tableEntry.location.line === sourceLocation.line)
+    } else {
+        return scenario.location.line === sourceLocation.line
+    }
+}
+
+function getStepFromFeature (feature, stepIndex) {
+    let combinedSteps = []
+    feature.children.forEach((child) => { combinedSteps = combinedSteps.concat(child.steps) })
+    return combinedSteps[stepIndex]
 }

--- a/lib/cucumberEventListener.js
+++ b/lib/cucumberEventListener.js
@@ -95,13 +95,22 @@ export class CucumberEventListener extends EventEmitter {
 
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
-        const scenario = doc.feature.children.find(child => child.location.line === sourceLocation.line)
-        const preparedTestCase = this.testCasePreparedEvents.find(tcpe => tcpe.sourceLocation.uri === uri && tcpe.sourceLocation.line === sourceLocation.line)
-        const preparedTestCaseStep = preparedTestCase.steps[testStepStartedEvent.index]
-        const allSteps = feature.children.map(child => child.steps).reduce((list, childSteps) => list.concat(childSteps), [])
-        const step = allSteps.find(childStep => childStep.location.line === preparedTestCaseStep.sourceLocation.line)
+        const scenario = doc.feature.children.find((child) => {
+            if (child.type.indexOf('ScenarioOutline') > -1) {
+                return child.examples[0].tableBody.some(function (tableEntry) {
+                    return tableEntry.location.line === sourceLocation.line
+                })
+            } else {
+                return child.location.line === sourceLocation.line
+            }
+        })
+        let combinedSteps = []
+        feature.children.forEach(function (child) {
+            combinedSteps = combinedSteps.concat(child.steps)
+        })
+        const step = combinedSteps[testStepStartedEvent.index]
 
-        this.emit('before-step', uri, feature, scenario, step)
+        this.emit('before-step', uri, feature, scenario, step, sourceLocation)
     }
 
     // testCasePreparedEvent = {
@@ -117,17 +126,13 @@ export class CucumberEventListener extends EventEmitter {
     // }
     onTestCasePrepared (testCasePreparedEvent) {
         this.testCasePreparedEvents.push(testCasePreparedEvent)
-        const sourceLocation = testCasePreparedEvent.sourceLocation
-        const uri = sourceLocation.uri
+        const steps = testCasePreparedEvent.steps
 
-        const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
-        const scenario = doc.feature.children.find(child => child.location.line === sourceLocation.line)
-        const scenarioHasHooks = scenario.steps.filter((step) => step.type === 'Hook').length > 0
+        const scenarioHasHooks = steps.filter((step) => step.type === 'Hook').length > 0
         if (scenarioHasHooks) {
             return
         }
-        const allSteps = testCasePreparedEvent.steps
-        allSteps.forEach((step, idx) => {
+        steps.forEach((step, idx) => {
             if (!step.sourceLocation) {
                 step.sourceLocation = { line: step.actionLocation.line, column: 0, uri: step.actionLocation.uri }
                 const hook = {
@@ -136,7 +141,7 @@ export class CucumberEventListener extends EventEmitter {
                     keyword: 'Hook',
                     text: ''
                 }
-                scenario.steps.splice(idx, 0, hook)
+                steps.splice(idx, 0, hook)
             }
         })
     }
@@ -154,14 +159,23 @@ export class CucumberEventListener extends EventEmitter {
 
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
-        const scenario = doc.feature.children.find(child => child.location.line === sourceLocation.line)
-        const preparedTestCase = this.testCasePreparedEvents.find(tcpe => tcpe.sourceLocation.uri === uri && tcpe.sourceLocation.line === sourceLocation.line)
-        const preparedTestCaseStep = preparedTestCase.steps[testStepFinishedEvent.index]
-        const allSteps = feature.children.map(child => child.steps).reduce((list, childSteps) => list.concat(childSteps), [])
-        const step = allSteps.find(childStep => childStep.location.line === preparedTestCaseStep.sourceLocation.line)
+        const scenario = doc.feature.children.find((child) => {
+            if (child.type.indexOf('ScenarioOutline') > -1) {
+                return child.examples[0].tableBody.some(function (tableEntry) {
+                    return tableEntry.location.line === sourceLocation.line
+                })
+            } else {
+                return child.location.line === sourceLocation.line
+            }
+        })
+        let combinedSteps = []
+        feature.children.forEach(function (child) {
+            combinedSteps = combinedSteps.concat(child.steps)
+        })
+        const step = combinedSteps[testStepFinishedEvent.index]
         const result = testStepFinishedEvent.result
 
-        this.emit('after-step', uri, feature, scenario, step, result)
+        this.emit('after-step', uri, feature, scenario, step, result, sourceLocation)
     }
 
     // testCaseFinishedEvent = {
@@ -174,9 +188,17 @@ export class CucumberEventListener extends EventEmitter {
 
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
-        const scenario = doc.feature.children.find(child => child.location.line === sourceLocation.line)
+        const scenario = doc.feature.children.find((child) => {
+            if (child.type.indexOf('ScenarioOutline') > -1) {
+                return child.examples[0].tableBody.some(function (tableEntry) {
+                    return tableEntry.location.line === sourceLocation.line
+                })
+            } else {
+                return child.location.line === sourceLocation.line
+            }
+        })
 
-        this.emit('after-scenario', uri, feature, scenario)
+        this.emit('after-scenario', uri, feature, scenario, sourceLocation)
     }
 
     // testRunFinishedEvent = {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -55,7 +55,7 @@ class CucumberReporter {
         })
     }
 
-    handleBeforeStep (uri, feature, scenario, step) {
+    handleBeforeStep (uri, feature, scenario, step, sourceLocation) {
         this.testStart = new Date()
 
         this.emit('test:start', {
@@ -63,7 +63,7 @@ class CucumberReporter {
             title: step.text,
             type: 'test',
             file: uri,
-            parent: this.getUniqueIdentifier(scenario),
+            parent: this.getUniqueIdentifier(scenario, sourceLocation),
             duration: new Date() - this.testStart,
             tags: scenario.tags,
             featureName: feature.name,
@@ -71,7 +71,7 @@ class CucumberReporter {
         })
     }
 
-    handleAfterStep (uri, feature, scenario, step, result) {
+    handleAfterStep (uri, feature, scenario, step, result, sourceLocation) {
         let e = 'undefined'
         switch (result.status) {
         case Status.FAILED:
@@ -153,7 +153,7 @@ class CucumberReporter {
             title: stepTitle.trim(),
             type: 'test',
             file: uri,
-            parent: this.getUniqueIdentifier(scenario),
+            parent: this.getUniqueIdentifier(scenario, sourceLocation),
             error: error,
             duration: new Date() - this.testStart,
             tags: scenario.tags,
@@ -162,9 +162,9 @@ class CucumberReporter {
         })
     }
 
-    handleAfterScenario (uri, feature, scenario) {
+    handleAfterScenario (uri, feature, scenario, sourceLocation) {
         this.emit('suite:end', {
-            uid: this.getUniqueIdentifier(scenario),
+            uid: this.getUniqueIdentifier(scenario, sourceLocation),
             title: this.getTitle(scenario),
             parent: this.getUniqueIdentifier(feature),
             type: 'suite',
@@ -248,17 +248,31 @@ class CucumberReporter {
         return type.uri.replace(process.cwd(), '')
     }
 
-    getUniqueIdentifier (target) {
+    getUniqueIdentifier (target, sourceLocation) {
+        let name
+        let line
+
         if (target.type === 'Hook') {
-            const name = path.basename(target.location.uri)
-            const line = target.location.line
+            name = path.basename(target.location.uri)
+            line = target.location.line
+        } else if (target.type === 'ScenarioOutline') {
+            name = target.name || target.text
+            line = sourceLocation.line;
 
-            return name + line
+            target.examples[0].tableHeader.cells.forEach(function (header, idx) {
+                if (name.indexOf('<' + header.value + '>') > -1) {
+                    target.examples[0].tableBody.forEach(function (tableEntry) {
+                        if (tableEntry.location.line === sourceLocation.line) {
+                            name = name.replace('<' + header.value + '>', tableEntry.cells[idx].value)
+                        }
+                    })
+                }
+            })
+        } else {
+            name = target.name || target.text
+            const location = target.location || target.locations[0]
+            line = (location && location.line) || ''
         }
-
-        const name = target.name || target.text
-        const location = target.location || target.locations[0]
-        const line = (location && location.line) || ''
 
         return name + line
     }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -257,11 +257,11 @@ class CucumberReporter {
             line = target.location.line
         } else if (target.type === 'ScenarioOutline') {
             name = target.name || target.text
-            line = sourceLocation.line;
+            line = sourceLocation.line
 
-            target.examples[0].tableHeader.cells.forEach(function (header, idx) {
+            target.examples[0].tableHeader.cells.forEach((header, idx) => {
                 if (name.indexOf('<' + header.value + '>') > -1) {
-                    target.examples[0].tableBody.forEach(function (tableEntry) {
+                    target.examples[0].tableBody.forEach((tableEntry) => {
                         if (tableEntry.location.line === sourceLocation.line) {
                             name = name.replace('<' + header.value + '>', tableEntry.cells[idx].value)
                         }

--- a/test/fixtures/sample.feature
+++ b/test/fixtures/sample.feature
@@ -13,3 +13,12 @@ Feature: Example feature
   Scenario: Foo Baz
     When  I click on link "=Also Google"
     Then  should the title of the page be "Google"
+
+  Scenario Outline: Foo Bar Baz
+     When  I click on link "<link>"
+     Then  should the title of the page be "<pageTitle>"
+
+     Examples:
+         | link          | pageTitle |
+         | =Google       | Google    |
+         | =Also Google  | Google    |

--- a/test/hooks.spec.js
+++ b/test/hooks.spec.js
@@ -106,7 +106,7 @@ describe('CucumberAdapter executes hooks using native Promises', () => {
 
         it('should contain right scenario data', () => {
             let scenario = beforeScenarioHook.args[0]
-            scenario.name.should.be.equal('Foo Baz')
+            scenario.name.should.startWith('Foo')
         })
     })
 
@@ -128,7 +128,7 @@ describe('CucumberAdapter executes hooks using native Promises', () => {
 
         it('should contain right step data', () => {
             let step = beforeStepHook.args[0]
-            step.text.should.be.equal(`should the title of the page be "Google"`)
+            step.text.should.startWith(`should the title of the page be`)
         })
     })
 
@@ -215,7 +215,7 @@ describe('CucumberAdapter executes hooks using native Promises', () => {
 
         it('should contain right scenario data', () => {
             let scenario = afterScenarioHook.args[0]
-            scenario.name.should.be.equal('Foo Baz')
+            scenario.name.should.startWith('Foo')
         })
     })
 


### PR DESCRIPTION
Hi,

I ran into issues with using background steps and scenario outlines. After checking in the issues I saw that multiple people had issues with this and since our company is trying to move to webdriverio with Cucumber I want the current test cases that we had to work. 

So after checking why the errors occurred I found that in the cucumberEventListener no scenario was found when just checking on the line number as for a scenario outline the line number was the one for the example. For that I made a change in how a scenario is found as now if go over a scenario outline I check if there is an example attached to that scenario which has the line of sourceLocation as it is passed to the function. if it is anything else the check stays the same.

For the background tasks I found that the background tasks were not in the report and also the execution would stop a step too soon. to prevent that from happening I iterate over all the children of the feature (which at runtime is the background and the currently executing scenario) and simply concat the steps of these in a new array from which (as it was) we pick the correct step with the index passed.
I found that what was there unnecessarily complicated actually.

When those 2 things were fixed I ran into an issue with the reporter when it tried to find the scenario at Runtime. This was because the scenario name passed would not contain the example data that is there on Runtime. e.g. we would pass "I go to google with searchterm <searchterm>" and in Runtime the scenario names would be "I go to google with searchterm Cucumberjs".  To fix this the sourceLocation was needed to be able to find example that is being executed which is only know in the eventListener. Therefore is passed that parameter to the function in reporter.js and from there to the getUniqueIdentifier function in reporter.js. There it is checked if a scenario outline is processed and go through the examples. When the right example is found the placeholder is replaced with the correct example data. which is then returned and passed to cucumber.