### PR TITLE
Fixing issue #138

### DIFF
--- a/lib/cucumberEventListener.js
+++ b/lib/cucumberEventListener.js
@@ -96,7 +96,7 @@ export class CucumberEventListener extends EventEmitter {
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
         const scenario = feature.children.find((child) => compareScenenarioLineWithSourceLine(child, sourceLocation))
-        const step = getStepFromFeature(feature, testStepStartedEvent.index)
+        const step = getStepFromFeature(feature, testStepStartedEvent.index, sourceLocation)
 
         this.emit('before-step', uri, feature, scenario, step, sourceLocation)
     }
@@ -148,7 +148,7 @@ export class CucumberEventListener extends EventEmitter {
         const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
         const feature = doc.feature
         const scenario = feature.children.find((child) => compareScenenarioLineWithSourceLine(child, sourceLocation))
-        const step = getStepFromFeature(feature, testStepFinishedEvent.index)
+        const step = getStepFromFeature(feature, testStepFinishedEvent.index, sourceLocation)
         const result = testStepFinishedEvent.result
 
         this.emit('after-step', uri, feature, scenario, step, result, sourceLocation)
@@ -217,8 +217,13 @@ function compareScenenarioLineWithSourceLine (scenario, sourceLocation) {
     }
 }
 
-function getStepFromFeature (feature, stepIndex) {
+function getStepFromFeature (feature, stepIndex, sourceLocation) {
     let combinedSteps = []
-    feature.children.forEach((child) => { combinedSteps = combinedSteps.concat(child.steps) })
+    feature.children.forEach((child) => {
+        if (child.type.indexOf('Scenario') > -1 && !compareScenenarioLineWithSourceLine(child, sourceLocation)) {
+            return
+        }
+        combinedSteps = combinedSteps.concat(child.steps)
+    })
     return combinedSteps[stepIndex]
 }

--- a/lib/cucumberEventListener.js
+++ b/lib/cucumberEventListener.js
@@ -114,13 +114,18 @@ export class CucumberEventListener extends EventEmitter {
     // }
     onTestCasePrepared (testCasePreparedEvent) {
         this.testCasePreparedEvents.push(testCasePreparedEvent)
-        const steps = testCasePreparedEvent.steps
+        const sourceLocation = testCasePreparedEvent.sourceLocation
+        const uri = sourceLocation.uri
 
-        const scenarioHasHooks = steps.filter((step) => step.type === 'Hook').length > 0
+        const doc = this.gherkinDocEvents.find(gde => gde.uri === uri).document
+        const scenario = doc.feature.children.find((child) => compareScenenarioLineWithSourceLine(child, sourceLocation))
+
+        const scenarioHasHooks = scenario.steps.filter((step) => step.type === 'Hook').length > 0
         if (scenarioHasHooks) {
             return
         }
-        steps.forEach((step, idx) => {
+        const allSteps = testCasePreparedEvent.steps
+        allSteps.forEach((step, idx) => {
             if (!step.sourceLocation) {
                 step.sourceLocation = { line: step.actionLocation.line, column: 0, uri: step.actionLocation.uri }
                 const hook = {
@@ -129,7 +134,7 @@ export class CucumberEventListener extends EventEmitter {
                     keyword: 'Hook',
                     text: ''
                 }
-                steps.splice(idx, 0, hook)
+                scenario.steps.splice(idx, 0, hook)
             }
         })
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "release:major": "np major",
     "test": "run-s eslint test:unit build test:postadapter",
     "test:ci": "run-s clean eslint build test:cover test:postadapter",
-    "test:unit": "mocha --compilers js:babel-core/register \"./test/!(adapter.spec).js\"",
+    "test:unit": "mocha --bail --compilers js:babel-core/register \"./test/!(adapter.spec).js\"",
     "test:postadapter": "mocha test/adapter.spec.js",
     "test:cover": "babel-node ./node_modules/.bin/isparta cover --include 'lib/*.js' _mocha -- \"test/!(adapter.spec).js\"",
     "prepare": "npm prune",

--- a/test/hooks.spec.js
+++ b/test/hooks.spec.js
@@ -193,7 +193,7 @@ describe('CucumberAdapter executes hooks using native Promises', () => {
 
         it('should contain right step data', () => {
             let step = afterStepHook.args[0]
-            step.text.should.be.equal(`should the title of the page be "Google"`)
+            step.text.should.startWith(`should the title of the page be`)
         })
     })
 


### PR DESCRIPTION
This is the fix for issue #138 
By checking in the getStepFromFeature function if we are processing a scenario and if so if we have the currently executing scenario the difference with the 2.2.0 version that appeared is gone. 

I have checked this with the cucumber-boilerplate project as well as my personal project that it works