### PR TITLE
Add possibility to pass options to the compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Require files with the given EXTENSION after requiring MODULE.
 
 Type: `String[]`<br>
 Default: `*[]*`<br>
-Example: `['js:babel-core/register']`
+Example: `['js:babel-core/register']`<br>
+To passe options to the compiler use `[[String, options]]`<br>
+Example: `[ ['js:babel-register', { ignore: [] }] ]`
 
 ### failAmbiguousDefinitions
 **Please note that this is a wdio-cucumber-framework specific option and not recognized by cucumber-js itself**

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -98,8 +98,13 @@ class CucumberAdapter {
 
     registerCompilers () {
         this.cucumberOpts.compiler.forEach(compiler => {
-            const parts = compiler.split(':')
-            require(parts[1])
+            if (compiler instanceof Array) {
+                let parts = compiler[0].split(':')
+                require(parts[1])(compiler[1])
+            } else {
+                let parts = compiler.split(':')
+                require(parts[1])
+            }
         })
     }
 

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -1,12 +1,6 @@
 const path = require('path')
 const { CucumberAdapter } = require('../build/adapter')
 
-const conf = {
-    cucumberOpts: {
-        compiler: [],
-        require: [path.join(__dirname, '/fixtures/es6-definition.js')]
-    }
-}
 const feature = ['./test/fixtures/es6.feature']
 
 const NOOP = function () {}
@@ -27,6 +21,15 @@ WebdriverIO.prototype = {
 process.send = NOOP
 
 describe('adapter', function () {
+    let conf
+    beforeEach(() => {
+        conf = {
+            cucumberOpts: {
+                compiler: [],
+                require: [path.join(__dirname, '/fixtures/es6-definition.js')]
+            }
+        }
+    })
     describe('should use the compiler as defined in the options', function () {
         /**
          * Do not change the order of the specs
@@ -46,6 +49,17 @@ describe('adapter', function () {
 
         it('should run if the compiler is defined', function () {
             conf.cucumberOpts.compiler.push('js:babel-register')
+
+            global.browser = new WebdriverIO()
+            global.browser.options = {}
+            const adapter = new CucumberAdapter(0, conf, feature, {})
+            global.browser.getPrototype = function () { return WebdriverIO.prototype }
+            return adapter.run().then((res) => {
+                res.should.equal(0, 'test ok!')
+            })
+        })
+        it('should run if the compiler is defined with options', function () {
+            conf.cucumberOpts.compiler.push(['js:babel-register', { ignore: ['node_modules'] }])
 
             global.browser = new WebdriverIO()
             global.browser.options = {}


### PR DESCRIPTION
Hi,
I add possibility to pass options to the compiler.  

To pass options to the compiler use [[String, options]]
Example `[ ['js:babel-register', { ignore: [] }] ]`