### PR TITLE
fixes #162

### DIFF
--- a/lib/cucumberEventListener.js
+++ b/lib/cucumberEventListener.js
@@ -229,7 +229,7 @@ function attachEventLogger (eventBroadcaster) {
 
 export function compareScenarioLineWithSourceLine (scenario, sourceLocation) {
     if (scenario.type.indexOf('ScenarioOutline') > -1) {
-        return scenario.examples[0].tableBody.some((tableEntry) => tableEntry.location.line === sourceLocation.line)
+        return scenario.examples.some((example) => example.tableBody.some((tableEntry) => tableEntry.location.line === sourceLocation.line))
     } else {
         return scenario.location.line === sourceLocation.line
     }

--- a/test/fixtures/tags-step-definition.js
+++ b/test/fixtures/tags-step-definition.js
@@ -1,0 +1,16 @@
+var assert = require('assert')
+var { Given, When, Then } = require('cucumber')
+
+Given('I go on the website {string}', {wrapperOptions: {retry: 2}}, function (url) {
+    return browser.url(url)
+})
+
+When('I click on link {string}', function (selector) {
+    return browser.click(selector)
+})
+
+Then('should the title of the page be {string}', function (expectedTitle) {
+    return browser.getTitle().then((title) => {
+        assert.equal(title, expectedTitle)
+    })
+})

--- a/test/fixtures/tags.feature
+++ b/test/fixtures/tags.feature
@@ -1,0 +1,22 @@
+Feature: Tags feature
+  As a test script of wdio-cucumber-framework
+  I should only execute scenarios matching the tag expression
+  So that only the right scenarios are executed
+
+  Background: Repeated setup
+    Given I go on the website "http://webdriver.io"
+
+  Scenario Outline: Clicking the link opens the right page
+     When  I click on link "<link>"
+     Then  should the title of the page be "<pageTitle>"
+
+     @ex1
+     Examples:
+         | link          | pageTitle |
+         | =Google       | Google    |
+         | =Also Google  | Google    |
+
+    @ex2
+    Scenario: Foo Bar
+        When  I click on link "=Google"
+        Then  should the title of the page be "Google"

--- a/test/fixtures/tags.match.scenario.conf.js
+++ b/test/fixtures/tags.match.scenario.conf.js
@@ -1,0 +1,28 @@
+import path from 'path'
+
+const NOOP = () => {}
+
+export default {
+    capabilities: {
+        browserName: 'chrome'
+    },
+
+    cucumberOpts: {
+        timeout: 5000,
+        require: [path.join(__dirname, '/tags-step-definition.js')],
+        tagExpression: '@ex2'
+    },
+
+    onPrepare: NOOP,
+    before: NOOP,
+    beforeSuite: NOOP,
+    beforeHook: NOOP,
+    afterHook: NOOP,
+    beforeTest: NOOP,
+    beforeCommand: NOOP,
+    afterCommand: NOOP,
+    afterTest: NOOP,
+    afterSuite: NOOP,
+    after: NOOP,
+    onComplete: NOOP
+}

--- a/test/fixtures/tags.match.so.conf.js
+++ b/test/fixtures/tags.match.so.conf.js
@@ -1,0 +1,28 @@
+import path from 'path'
+
+const NOOP = () => {}
+
+export default {
+    capabilities: {
+        browserName: 'chrome'
+    },
+
+    cucumberOpts: {
+        timeout: 5000,
+        require: [path.join(__dirname, '/tags-step-definition.js')],
+        tagExpression: '@ex1'
+    },
+
+    onPrepare: NOOP,
+    before: NOOP,
+    beforeSuite: NOOP,
+    beforeHook: NOOP,
+    afterHook: NOOP,
+    beforeTest: NOOP,
+    beforeCommand: NOOP,
+    afterCommand: NOOP,
+    afterTest: NOOP,
+    afterSuite: NOOP,
+    after: NOOP,
+    onComplete: NOOP
+}

--- a/test/fixtures/tags.no.match.conf.js
+++ b/test/fixtures/tags.no.match.conf.js
@@ -1,0 +1,28 @@
+import path from 'path'
+
+const NOOP = () => {}
+
+export default {
+    capabilities: {
+        browserName: 'chrome'
+    },
+
+    cucumberOpts: {
+        timeout: 5000,
+        require: [path.join(__dirname, '/tags-step-definition.js')],
+        tagExpression: '@ex0'
+    },
+
+    onPrepare: NOOP,
+    before: NOOP,
+    beforeSuite: NOOP,
+    beforeHook: NOOP,
+    afterHook: NOOP,
+    beforeTest: NOOP,
+    beforeCommand: NOOP,
+    afterCommand: NOOP,
+    afterTest: NOOP,
+    afterSuite: NOOP,
+    after: NOOP,
+    onComplete: NOOP
+}

--- a/test/tags.spec.js
+++ b/test/tags.spec.js
@@ -1,0 +1,82 @@
+import soMatchConf from './fixtures/tags.match.so.conf'
+import scenarioMatchConf from './fixtures/tags.match.scenario.conf'
+import noMatchConf from './fixtures/tags.no.match.conf'
+import { CucumberAdapter } from '../lib/adapter'
+
+const specs = ['./test/fixtures/tags.feature']
+
+const NOOP = () => {}
+
+const WebdriverIO = class {}
+WebdriverIO.prototype = {
+    /**
+     * task of this command is to add 1 so we can have a simple demo test like
+     * browser.command(1).should.be.equal(2)
+     */
+    url: () => new Promise((resolve) => {
+        setTimeout(() => resolve(), 2000)
+    }),
+    click: () => new Promise((resolve) => {
+        setTimeout(() => resolve(), 2000)
+    }),
+    getTitle: (ms = 500) => new Promise((resolve) => {
+        setTimeout(() => resolve('Google'), ms)
+    }),
+    pause: (ms = 500) => new Promise((resolve) => {
+        setTimeout(() => resolve(), ms)
+    })
+}
+
+process.send = NOOP
+
+let timeToExecute
+describe('Tag Match test', () => {
+    describe('Test matching Tag found at Scenario Outline Example', () => {
+        before(async () => {
+            global.browser = new WebdriverIO()
+            const adapter = new CucumberAdapter(0, soMatchConf, specs, {})
+            global.browser.getPrototype = () => WebdriverIO.prototype
+
+            const start = new Date().getTime();
+            (await adapter.run()).should.be.equal(0, 'actual test failed')
+            timeToExecute = new Date().getTime() - start
+        })
+
+        it('should take more than the expected amount of time to execute two test', () => {
+            timeToExecute.should.be.above(10000)
+        })
+    })
+
+    describe('Test matching Tag found at Scenario', () => {
+        before(async () => {
+            global.browser = new WebdriverIO()
+            const adapter = new CucumberAdapter(0, scenarioMatchConf, specs, {})
+            global.browser.getPrototype = () => WebdriverIO.prototype
+
+            const start = new Date().getTime();
+            (await adapter.run()).should.be.equal(0, 'actual test failed')
+            timeToExecute = new Date().getTime() - start
+        })
+
+        it('should take more than the expected amount of time to execute one test', () => {
+            timeToExecute.should.be.above(7000)
+        })
+    })
+
+    describe('Test matching Tag not found', () => {
+        before(async () => {
+            global.browser = new WebdriverIO()
+            global.browser.options = {}
+            const adapter = new CucumberAdapter(0, noMatchConf, specs, {})
+            global.browser.getPrototype = () => WebdriverIO.prototype
+
+            const start = new Date().getTime();
+            (await adapter.run()).should.be.equal(0, 'actual test failed')
+            timeToExecute = new Date().getTime() - start
+        })
+
+        it('should take the less than the expected amount of time to execute no tests', () => {
+            timeToExecute.should.be.below(6000)
+        })
+    })
+})


### PR DESCRIPTION
Surrounded the example.tableBody with another some function that runs through the examples first. This fixes issue #162.