### PR TITLE
Allowing to specify a scenario by its line number

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -70,14 +70,14 @@ class CucumberAdapter {
         const reporter = new CucumberReporter(eventBroadcaster, reporterOptions, this.cid, this.specs)
 
         const pickleFilter = new Cucumber.PickleFilter({
-            featurePaths: this.spec,
+            featurePaths: this.specs,
             names: this.cucumberOpts.name,
             tagExpression: this.cucumberOpts.tagExpression
         })
         const testCases = await Cucumber.getTestCasesFromFilesystem({
             cwd: this.cwd,
             eventBroadcaster,
-            featurePaths: this.specs,
+            featurePaths: this.specs.map(spec => spec.replace(/(:\d+)*$/g, '')),
             order: this.cucumberOpts.order,
             pickleFilter
         })

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -70,4 +70,17 @@ describe('adapter', function () {
             })
         })
     })
+    describe('should run passed spec files', function () {
+        it('should allow to specify a scenario by its line number', function () {
+            conf.cucumberOpts.compiler.push('js:babel-register')
+
+            global.browser = new WebdriverIO()
+            global.browser.options = {}
+            const adapter = new CucumberAdapter(0, conf, ['./test/fixtures/es6.feature:6'], {})
+            global.browser.getPrototype = function () { return WebdriverIO.prototype }
+            return adapter.run().then((res) => {
+                res.should.equal(0, 'test ok!')
+            })
+        })
+    })
 })


### PR DESCRIPTION
This pull request resolves #159 by allowing to specify a scenario by its line number. webdriverio [v4.11.1](https://github.com/webdriverio/webdriverio/blob/v4.14.1/docs/guide/testrunner/organizesuite.md#run-selected-tests) supports running single scenario. It would be great to add this support to v5 as well.

By the way may I ask you to update the v4.webdriver.io site to reflect v4.11.1 changes? In section [Run Selected Tests](http://v4.webdriver.io/guide/testrunner/organizesuite.html#Run-Selected-Tests) there is no information on this feature.